### PR TITLE
feat(application): create shared app

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -4,16 +4,18 @@ package main
 import (
     "net/http"
 
+    "github.com/Lianathanoj/goyagi/pkg/application"
     "github.com/Lianathanoj/goyagi/pkg/server"
     "github.com/lob/logger-go"
 )
 
 func main() {
     log := logger.New()
+    app := application.New()
 
-    srv := server.New()
+    srv := server.New(app)
 
-    log.Info("server started")
+    log.Info("server started", logger.Data{"port": app.Config.Port})
 
     err := srv.ListenAndServe()
     if err != nil && err != http.ErrServerClosed {

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -1,0 +1,19 @@
+// pkg/application/application.go
+package application
+
+import (
+    "github.com/Lianathanoj/goyagi/pkg/config"
+)
+
+// App contains necessary references that will be persisted throughout the
+// application's lifecycle.
+type App struct {
+    Config config.Config
+}
+
+// New creates a new instance of App
+func New() App {
+    cfg := config.New()
+
+    return App{cfg}
+}

--- a/pkg/application/application_test.go
+++ b/pkg/application/application_test.go
@@ -1,0 +1,14 @@
+// pkg/application/application_test.go
+package application
+
+import (
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+    app := New()
+    assert.NotNil(t, app)
+    assert.NotNil(t, app.Config)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,32 @@
+// pkg/config/config.go
+package config
+
+import (
+    "os"
+)
+
+// Config contains the environment specific configuration values needed by the
+// application.
+type Config struct {
+    Environment string
+    Port        int
+}
+
+const environmentENV = "ENVIRONMENT"
+
+// New returns an instance of Config based on the "ENVIRONMENT" environment
+// variable.
+func New() Config {
+    cfg := Config{
+        Port: 3000,
+    }
+
+    switch os.Getenv(environmentENV) {
+    case "development", "":
+        loadDevelopmentConfig(&cfg)
+    case "test":
+        loadTestConfig(&cfg)
+    }
+
+    return cfg
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,33 @@
+// pkg/config/config_test.go
+package config
+
+import (
+    "os"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+    cfg := New()
+    assert.NotNil(t, cfg, "returned config shouldn't be nil")
+}
+
+func TestEnvironments(t *testing.T) {
+    originalEnv := os.Getenv(environmentENV)
+    defer func() {
+        err := os.Setenv(environmentENV, originalEnv)
+        require.NoError(t, err)
+    }()
+
+    envs := []string{"development", "test"}
+
+    for _, env := range envs {
+        err := os.Setenv(environmentENV, env)
+        require.NoError(t, err)
+
+        cfg := New()
+        assert.Equal(t, cfg.Environment, env, "incorrect environment")
+    }
+}

--- a/pkg/config/development.go
+++ b/pkg/config/development.go
@@ -1,0 +1,15 @@
+// pkg/config/development.go
+package config
+
+import (
+    "os"
+    "strconv"
+)
+
+func loadDevelopmentConfig(cfg *Config) {
+    port, err := strconv.Atoi(os.Getenv("PORT"))
+    if err == nil {
+        cfg.Port = port
+    }
+    cfg.Environment = "development"
+}

--- a/pkg/config/test.go
+++ b/pkg/config/test.go
@@ -1,0 +1,6 @@
+// pkg/config/test.go
+package config
+
+func loadTestConfig(cfg *Config) {
+    cfg.Environment = "test"
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -6,6 +6,7 @@ import (
     "fmt"
     "net/http"
 
+    "github.com/Lianathanoj/goyagi/pkg/application"
     "github.com/Lianathanoj/goyagi/pkg/health"
     "github.com/Lianathanoj/goyagi/pkg/signals"
     "github.com/labstack/echo"
@@ -13,7 +14,7 @@ import (
 )
 
 // New returns a new HTTP server with the registered routes.
-func New() *http.Server {
+func New(app application.App) *http.Server {
     log := logger.New()
 
     e := echo.New()
@@ -21,7 +22,7 @@ func New() *http.Server {
     health.RegisterRoutes(e)
 
     srv := &http.Server{
-        Addr:    fmt.Sprintf(":%d", 3000),
+        Addr:    fmt.Sprintf(":%d", app.Config.Port),
         Handler: e,
     }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -6,12 +6,16 @@ import (
     "net/http/httptest"
     "testing"
 
+    "github.com/Lianathanoj/goyagi/pkg/application"
     "github.com/stretchr/testify/assert"
     "github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
-    srv := New()
+    app, err := application.New()
+    require.Nil(t, err, "unexpected error when creating application");
+
+    srv := New(app)
 
     t.Run("serves registered endpoint", func(tt *testing.T) {
         w := httptest.NewRecorder()

--- a/vendor/github.com/getsentry/raven-go/Dockerfile.test
+++ b/vendor/github.com/getsentry/raven-go/Dockerfile.test
@@ -1,0 +1,13 @@
+FROM golang:1.7
+
+RUN mkdir -p /go/src/github.com/getsentry/raven-go
+WORKDIR /go/src/github.com/getsentry/raven-go
+ENV GOPATH /go
+
+RUN go install -race std && go get golang.org/x/tools/cmd/cover
+
+COPY . /go/src/github.com/getsentry/raven-go
+
+RUN go get -v ./...
+
+CMD ["./runtests.sh"]


### PR DESCRIPTION
Previous PR: #2 (merge this in only after #2 has gone through. Also remember to rebase after merge.)

**What:** create an application package and a shared app struct which facilitates easier addition of modules/dependencies that can be passed down to other part of the Go application. For instance, we can pass config variables to the app struct which are required elsewhere.

**Why:** We utilize this method of sharing info as compared to using a global singleton to keep in-line with Go's (opinionated) recommendations. 