### PR TITLE
feat(endpoints): add retrieve and list movies

### DIFF
--- a/cmd/serve/main.go
+++ b/cmd/serve/main.go
@@ -20,7 +20,7 @@ func main() {
 
     log.Info("server started", logger.Data{"port": app.Config.Port})
 
-    err := srv.ListenAndServe()
+    err = srv.ListenAndServe()
     if err != nil && err != http.ErrServerClosed {
         log.Err(err).Fatal("server stopped")
     }

--- a/internal/test/routes.go
+++ b/internal/test/routes.go
@@ -1,0 +1,23 @@
+// internal/test/routes.go
+package test
+
+import (
+    "fmt"
+    "strings"
+
+    "github.com/labstack/echo"
+)
+
+// FilterRoutes takes in a slice of Echo routes and returns a slice of strings
+// with handler routes.
+func FilterRoutes(routes []*echo.Route) []string {
+    rs := []string{}
+
+    for _, r := range routes {
+        if strings.Contains(r.Name, "*handler") {
+            rs = append(rs, fmt.Sprintf("%s %s", r.Method, r.Path))
+        }
+    }
+
+    return rs
+}

--- a/pkg/model/movie.go
+++ b/pkg/model/movie.go
@@ -1,0 +1,11 @@
+// pkg/model/movie.go
+package model
+
+import "time"
+
+// Movie model
+type Movie struct {
+    ID          int       `json:"id"`
+    Title       string    `json:"title"`
+    ReleaseDate time.Time `json:"release_date"`
+}

--- a/pkg/movies/handlers.go
+++ b/pkg/movies/handlers.go
@@ -1,0 +1,46 @@
+// pkg/movies/handlers.go
+package movies
+
+import (
+    "net/http"
+    "github.com/Lianathanoj/goyagi/pkg/application"
+    "github.com/Lianathanoj/goyagi/pkg/model"
+
+    "github.com/go-pg/pg"
+    "github.com/labstack/echo"
+)
+
+type handler struct {
+    app application.App
+}
+
+
+func (h *handler) listHandler(c echo.Context) error {
+    var movies []*model.Movie
+
+    err := h.app.DB.
+        Model(&movies).
+        Order("id DESC").
+        Select()
+    if err != nil {
+        return err
+    }
+
+    return c.JSON(http.StatusOK, movies)
+}
+
+func (h *handler) retrieveHandler(c echo.Context) error {
+    id := c.Param("id")
+
+    var movie model.Movie
+
+    err := h.app.DB.Model(&movie).Where("id = ?", id).First()
+    if err != nil {
+        if err == pg.ErrNoRows {
+            return echo.NewHTTPError(http.StatusNotFound, "movie not found")
+        }
+        return err
+    }
+
+    return c.JSON(http.StatusOK, movie)
+}

--- a/pkg/movies/handlers_test.go
+++ b/pkg/movies/handlers_test.go
@@ -51,7 +51,7 @@ func TestRetrieveHandler(t *testing.T) {
         assert.Equal(tt, response.Title, "Iron Man")
     })
 
-    t.Run("returns 404 if user isn't found", func(tt *testing.T) {
+    t.Run("returns 404 if movie isn't found", func(tt *testing.T) {
         c, _ := newContext(tt, nil)
         c.SetParamNames("id")
         c.SetParamValues("9999")

--- a/pkg/movies/handlers_test.go
+++ b/pkg/movies/handlers_test.go
@@ -1,0 +1,82 @@
+// pkg/movies/handlers_test.go
+package movies
+
+import (
+    "bytes"
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+
+    "github.com/Lianathanoj/goyagi/pkg/application"
+    "github.com/Lianathanoj/goyagi/pkg/model"
+    "github.com/labstack/echo"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestListHandler(t *testing.T) {
+    h := newHandler(t)
+
+    t.Run("lists movies on success", func(tt *testing.T) {
+        c, rr := newContext(tt, nil)
+
+        err := h.listHandler(c)
+        assert.NoError(tt, err)
+        assert.Equal(tt, http.StatusOK, rr.Code)
+
+        var response []model.Movie
+        err = json.Unmarshal(rr.Body.Bytes(), &response)
+        require.NoError(tt, err)
+        assert.True(tt, len(response) >= 23)
+    })
+}
+
+func TestRetrieveHandler(t *testing.T) {
+    h := newHandler(t)
+
+    t.Run("retrieves movie on success", func(tt *testing.T) {
+        c, rr := newContext(tt, nil)
+        c.SetParamNames("id")
+        c.SetParamValues("1")
+
+        err := h.retrieveHandler(c)
+        assert.NoError(tt, err)
+        assert.Equal(tt, http.StatusOK, rr.Code)
+
+        var response model.Movie
+        err = json.Unmarshal(rr.Body.Bytes(), &response)
+        require.NoError(tt, err)
+        assert.Equal(tt, response.ID, 1)
+        assert.Equal(tt, response.Title, "Iron Man")
+    })
+
+    t.Run("returns 404 if user isn't found", func(tt *testing.T) {
+        c, _ := newContext(tt, nil)
+        c.SetParamNames("id")
+        c.SetParamValues("9999")
+
+        err := h.retrieveHandler(c)
+        assert.Contains(tt, err.Error(), "movie not found")
+    })
+}
+
+// newHandler returns a new handler to be used for tests.
+func newHandler(t *testing.T) handler {
+    t.Helper()
+
+    app, err := application.New()
+    require.NoError(t, err)
+    return handler{app}
+}
+
+// newContext returns a new echo.Context, and *httptest.ResponseRecorder to be
+// used for tests.
+func newContext(t *testing.T, payload []byte) (echo.Context, *httptest.ResponseRecorder) {
+    e := echo.New()
+    req := httptest.NewRequest(echo.GET, "/", bytes.NewReader(payload))
+    req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+    rr := httptest.NewRecorder()
+    c := e.NewContext(req, rr)
+    return c, rr
+}

--- a/pkg/movies/routes.go
+++ b/pkg/movies/routes.go
@@ -1,0 +1,25 @@
+// pkg/movies/routes.go
+package movies
+
+import (
+    "github.com/Lianathanoj/goyagi/pkg/application"
+    "github.com/labstack/echo"
+)
+
+// RegisterRoutes takes in an Echo router and registers routes onto it.
+func RegisterRoutes(e *echo.Echo, app application.App) {
+    g := e.Group("/movies")
+
+    // RegiserRoutes takes in an application.App struct and we wrap it around an
+    // internal handler struct. This allows us to create a methods over the
+    // handler struct that act as our endpoint handler functions. Doing this
+    // allows us to access our App struct (which contains references to all
+    // objects that need to only be instantiated once) from all of our handlers.
+    // If we ever need to add new dependencies to our App struct, we'll
+    // automatically make them available to all our handlers through this
+    // construct.
+    h := handler{app}
+
+    g.GET("", h.listHandler)
+    g.GET("/:id", h.retrieveHandler)
+}

--- a/pkg/movies/routes_test.go
+++ b/pkg/movies/routes_test.go
@@ -1,0 +1,23 @@
+// pkg/movies/routes_test.go
+package movies
+
+import (
+    "testing"
+
+    "github.com/Lianathanoj/goyagi/internal/test"
+    "github.com/Lianathanoj/goyagi/pkg/application"
+    "github.com/labstack/echo"
+    "github.com/stretchr/testify/assert"
+)
+
+func TestRegisterRoutes(t *testing.T) {
+    e := echo.New()
+    app := application.App{}
+
+    RegisterRoutes(e, app)
+
+    routes := test.FilterRoutes(e.Routes())
+    assert.Len(t, routes, 2)
+    assert.Contains(t, routes, "GET /movies")
+    assert.Contains(t, routes, "GET /movies/:id")
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -8,6 +8,7 @@ import (
 
     "github.com/Lianathanoj/goyagi/pkg/application"
     "github.com/Lianathanoj/goyagi/pkg/health"
+    "github.com/Lianathanoj/goyagi/pkg/movies"
     "github.com/Lianathanoj/goyagi/pkg/signals"
     "github.com/labstack/echo"
     "github.com/lob/logger-go"
@@ -20,6 +21,7 @@ func New(app application.App) *http.Server {
     e := echo.New()
 
     health.RegisterRoutes(e)
+    movies.RegisterRoutes(e, app)
 
     srv := &http.Server{
         Addr:    fmt.Sprintf(":%d", app.Config.Port),


### PR DESCRIPTION
Previous PR: #4 (merge this in only after #4 has gone through. Also remember to rebase after merge.)

**What:** Create movie model and add handlers & routes to retrieve a single movie by ID or list all movies. 

**Why:** We want to be able to demonstrate basic API requests through Go's environment after we have already setup the pertinent database config and migrations.

Example requests:
    * `curl localhost:3000/movies` for listing
    * `curl localhost:3000/movies/5` for retrieving