### PR TITLE
feat(movies): add create movies endpoint

### DIFF
--- a/pkg/movies/handlers.go
+++ b/pkg/movies/handlers.go
@@ -14,18 +14,44 @@ type handler struct {
     app application.App
 }
 
+func (h *handler) createHandler(c echo.Context) error {
+    // params is a struct that will have our payload bound and validated against
+    params := createParams{}
+    if err := c.Bind(&params); err != nil {
+        // if there is an error binding or validating the payload, return early with an error
+        return err
+    }
+
+    movie := model.Movie{
+        Title:       params.Title,
+        ReleaseDate: params.ReleaseDate,
+    }
+
+    _, err := h.app.DB.Model(&movie).Insert()
+    if err != nil {
+        return err
+    }
+
+    return c.JSON(http.StatusOK, movie)
+}
 
 func (h *handler) listHandler(c echo.Context) error {
+    params := listParams{}
+    if err := c.Bind(&params); err != nil {
+        return err
+    }
+
     var movies []*model.Movie
 
     err := h.app.DB.
         Model(&movies).
+        Limit(params.Limit).
+        Offset(params.Offset).
         Order("id DESC").
         Select()
     if err != nil {
         return err
     }
-
     return c.JSON(http.StatusOK, movies)
 }
 

--- a/pkg/movies/handlers_test.go
+++ b/pkg/movies/handlers_test.go
@@ -15,6 +15,23 @@ import (
     "github.com/stretchr/testify/require"
 )
 
+func TestCreateHandler(t *testing.T) {
+    h := newHandler(t)
+
+    t.Run("posts movie on success", func(tt *testing.T) {
+        c, rr := newContext(tt, []byte(`{ "title": "blah", "release_date": "2019-07-05T00:00:00Z" }`))
+
+        err := h.createHandler(c)
+        assert.NoError(tt, err)
+        assert.Equal(tt, http.StatusOK, rr.Code)
+
+        var response model.Movie
+        err = json.Unmarshal(rr.Body.Bytes(), &response)
+        require.NoError(tt, err)
+        assert.True(tt, response.Title == "blah")
+    })
+}
+
 func TestListHandler(t *testing.T) {
     h := newHandler(t)
 

--- a/pkg/movies/routes.go
+++ b/pkg/movies/routes.go
@@ -22,4 +22,5 @@ func RegisterRoutes(e *echo.Echo, app application.App) {
 
     g.GET("", h.listHandler)
     g.GET("/:id", h.retrieveHandler)
+    g.POST("", h.createHandler)
 }

--- a/pkg/movies/routes_test.go
+++ b/pkg/movies/routes_test.go
@@ -17,7 +17,8 @@ func TestRegisterRoutes(t *testing.T) {
     RegisterRoutes(e, app)
 
     routes := test.FilterRoutes(e.Routes())
-    assert.Len(t, routes, 2)
+    assert.Len(t, routes, 3)
     assert.Contains(t, routes, "GET /movies")
     assert.Contains(t, routes, "GET /movies/:id")
+    assert.Contains(t, routes, "POST /movies")
 }

--- a/pkg/movies/validators.go
+++ b/pkg/movies/validators.go
@@ -1,0 +1,13 @@
+package movies
+
+import "time"
+
+type createParams struct {
+	Title       string    `json:"title" mod:"trim" validate:"required,max=35"`
+	ReleaseDate time.Time `json:"release_date" validate:"omitempty"`
+}
+
+type listParams struct {
+	Limit  int `query:"limit" default:"10" validate:"min=0,max=100"`
+	Offset int `query:"offset" validate:"min=0"`
+}


### PR DESCRIPTION
Previous PR: #6 (merge this in only after #6 has gone through. Also remember to rebase after merge.)

**What:** Create validators (specifically for limits and offsets) which will be used as optional query params for the list endpoint. Furthermore, we create an endpoint and a corresponding unit test to create a movie.

**Why:** We want to add functionality for filters for listing movies as well as functionality for creating movies as part of the basic app.