### PR TITLE
feat(errors): add error handler and recovery middleware

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:fed1f537c2f1269fe475a8556c393fe466641682d73ef8fd0491cd3aa1e47bad"
+  name = "github.com/certifi/gocertifi"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "deb3ae2ef2610fde3330947281941c562861188b"
+  version = "2018.01.18"
+
+[[projects]]
   digest = "1:ed4582b92b69928dec6d82f78d1ad64863b89e631217bfdc5c63b3066a053eea"
   name = "github.com/creasty/defaults"
   packages = ["."]
@@ -16,6 +24,14 @@
   pruneopts = "UT"
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
+
+[[projects]]
+  digest = "1:d18f6f088d7d8365df47f49dfa24b6ff6701a941118ffda30c589d1bd954074b"
+  name = "github.com/getsentry/raven-go"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f04e7487e9a6b9d9837d52743fb5f40576c56411"
+  version = "v0.2.0"
 
 [[projects]]
   digest = "1:d02b94ed7089fc72fcd2e89c89df858c843470fe36788df39bf45e074293165e"
@@ -277,8 +293,10 @@
   analyzer-version = 1
   input-imports = [
     "github.com/creasty/defaults",
+    "github.com/getsentry/raven-go",
     "github.com/go-pg/pg",
     "github.com/go-pg/pg/orm",
+    "github.com/gofrs/uuid",
     "github.com/labstack/echo",
     "github.com/lob/logger-go",
     "github.com/pkg/errors",

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -4,6 +4,7 @@ package application
 import (
     "github.com/Lianathanoj/goyagi/pkg/config"
     "github.com/Lianathanoj/goyagi/pkg/database"
+    "github.com/Lianathanoj/goyagi/pkg/sentry"
     "github.com/go-pg/pg"
     "github.com/pkg/errors"
 )
@@ -13,6 +14,7 @@ import (
 type App struct {
     Config config.Config
     DB     *pg.DB
+    Sentry sentry.Sentry
 }
 
 // New creates a new instance of App
@@ -24,5 +26,10 @@ func New() (App, error) {
         return App{}, errors.Wrap(err, "application")
     }
 
-    return App{cfg, db}, nil
+    sentry, err := sentry.New(cfg)
+    if err != nil {
+        return App{}, errors.Wrap(err, "application")
+    }
+
+    return App{cfg, db, sentry}, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
     DatabasePassword string
     Environment      string
     Port             int
+    SentryDSN        string
 }
 
 const environmentENV = "ENVIRONMENT"
@@ -25,7 +26,8 @@ const environmentENV = "ENVIRONMENT"
 func New() Config {
     cfg := Config{
         Port: 3000,
-        DatabasePort: 5432 }
+        DatabasePort: 5432,
+        SentryDSN: os.Getenv("SENTRY_DSN"), }
 
     switch os.Getenv(environmentENV) {
     case "development", "":

--- a/pkg/errors/handler.go
+++ b/pkg/errors/handler.go
@@ -1,0 +1,60 @@
+// pkg/errors/handler.go
+package errors
+
+import (
+    "net/http"
+
+    "github.com/Lianathanoj/goyagi/pkg/application"
+    "github.com/Lianathanoj/goyagi/pkg/logger"
+    raven "github.com/getsentry/raven-go"
+    "github.com/labstack/echo"
+    loggergo "github.com/lob/logger-go"
+)
+
+type handler struct {
+    app application.App
+}
+
+// RegisterErrorHandler takes in an Echo router and registers routes onto it.
+func RegisterErrorHandler(e *echo.Echo, app application.App) {
+    h := handler{app}
+
+    e.HTTPErrorHandler = h.handleError
+}
+
+// handleError is an Echo error handler that uses HTTP errors accordingly, and any
+// generic error will be interpreted as an internal server error.
+func (h *handler) handleError(err error, c echo.Context) {
+    // Fetch the logger set into the echo.Context by the logger middleware.
+    // This logger has the request ID associated with this particular request.
+    log := logger.FromContext(c)
+
+    // Default our status code and message to a 500 error.
+    code := http.StatusInternalServerError
+    msg := http.StatusText(code)
+
+    // If we are bubbling up an HTTP error it must be because we specifically
+    // wanted to return this particular error and message. Set our status code
+    // and message to the ones specificed in the HTTP error.
+    if he, ok := err.(*echo.HTTPError); ok {
+        code = he.Code
+        msg = http.StatusText(code)
+    }
+
+    if code == http.StatusInternalServerError {
+        stacktrace := raven.NewException(err, raven.GetOrNewStacktrace(err, 0, 2, nil))
+        httpContext := raven.NewHttp(c.Request())
+        packet := raven.NewPacket(msg, stacktrace, httpContext)
+
+        h.app.Sentry.Client.Capture(packet, map[string]string{})
+    }
+
+    // Log our error with our child logger.
+    log.Root(loggergo.Data{"status_code": code}).Err(err).Error("request error")
+
+    // Return the error in the form of an HTTP response.
+    err = c.JSON(code, map[string]interface{}{"error": map[string]interface{}{"message": msg, "status_code": code}})
+    if err != nil {
+        log.Err(err).Error("error handler json error")
+    }
+}

--- a/pkg/errors/handler_test.go
+++ b/pkg/errors/handler_test.go
@@ -1,0 +1,87 @@
+// pkg/errors/handler_test.go
+
+package errors
+
+import (
+    "errors"
+    "net/http"
+    "testing"
+
+    "github.com/Lianathanoj/goyagi/internal/test"
+    "github.com/Lianathanoj/goyagi/pkg/application"
+    "github.com/Lianathanoj/goyagi/pkg/sentry"
+    "github.com/getsentry/raven-go"
+    "github.com/labstack/echo"
+    "github.com/stretchr/testify/assert"
+)
+
+// mockSentryClient is a dummy struct that adheres to the ravenClient
+// interface defined by in our sentry package. This allows us to create a mock
+// client that has the same function signature but doesn't actually make a
+// request to Sentry when invoked. While we do not assert the values that get
+// passed into the function you can assert or fail tests based on the values
+// that get pased in to the mock client functions.
+type mockSentryClient struct{}
+
+func (m mockSentryClient) Capture(packet *raven.Packet, captureTags map[string]string) (string, chan error) {
+    return "", nil
+}
+
+func TestHandler(t *testing.T) {
+    app := application.App{
+        Sentry: sentry.Sentry{
+            Client: mockSentryClient{}, // set the mock client instead of a real raven client
+        },
+    }
+    h := handler{app}
+
+    t.Run("surfaces generic errors as internal server errors", func(tt *testing.T) {
+        c, rr := test.NewContext(t, nil, echo.MIMEApplicationJSON)
+        err := errors.New("foo")
+
+        h.handleError(err, c)
+
+        assert.Equal(tt, http.StatusInternalServerError, rr.Code, "expected generic errors to be 500s")
+        assert.Contains(tt, rr.Body.String(), "Internal Server Error", "expected generic errors to have the correct message")
+    })
+
+    t.Run("surfaces HTTP errors transparently but obfuscates message", func(tt *testing.T) {
+        c, rr := test.NewContext(t, nil, echo.MIMEApplicationJSON)
+        err := echo.NewHTTPError(http.StatusForbidden, "foo")
+
+        h.handleError(err, c)
+
+        assert.Equal(tt, http.StatusForbidden, rr.Code, "expected HTTP errors to be correct")
+        assert.Contains(tt, rr.Body.String(), "Forbidden", "expected HTTP errors to have the correct message")
+    })
+
+    t.Run("overwrites HTTP 400 error messages", func(tt *testing.T) {
+        c, rr := test.NewContext(t, nil, echo.MIMEApplicationJSON)
+        err := echo.NewHTTPError(http.StatusBadRequest, "this shouldn't be sent to customers")
+
+        h.handleError(err, c)
+
+        assert.Equal(tt, http.StatusBadRequest, rr.Code, "expected HTTP errors to be correct")
+        assert.Contains(tt, rr.Body.String(), "Bad Request", "expected HTTP errors to have the correct message")
+    })
+
+    t.Run("overwrites HTTP 403 error messages", func(tt *testing.T) {
+        c, rr := test.NewContext(t, nil, echo.MIMEApplicationJSON)
+        err := echo.NewHTTPError(http.StatusForbidden, "this shouldn't be sent to customers")
+
+        h.handleError(err, c)
+
+        assert.Equal(tt, http.StatusForbidden, rr.Code, "expected HTTP errors to be correct")
+        assert.Contains(tt, rr.Body.String(), "Forbidden", "expected HTTP errors to have the correct message")
+    })
+
+    t.Run("overwrites HTTP 404 error messages", func(tt *testing.T) {
+        c, rr := test.NewContext(t, nil, echo.MIMEApplicationJSON)
+        err := echo.NewHTTPError(http.StatusNotFound, "this shouldn't be sent to customers")
+
+        h.handleError(err, c)
+
+        assert.Equal(tt, http.StatusNotFound, rr.Code, "expected HTTP errors to be correct")
+        assert.Contains(tt, rr.Body.String(), "Not Found", "expected HTTP errors to have the correct message")
+    })
+}

--- a/pkg/recovery/middleware.go
+++ b/pkg/recovery/middleware.go
@@ -1,0 +1,28 @@
+// pkg/recovery/middleware.go
+package recovery
+
+import (
+    "github.com/labstack/echo"
+    "github.com/pkg/errors"
+)
+
+// Middleware recovers from any possible panics in subsequent handlers
+// and funnels it to the error handler to be returned as a 500.
+func Middleware() func(next echo.HandlerFunc) echo.HandlerFunc {
+    return func(next echo.HandlerFunc) echo.HandlerFunc {
+        return func(c echo.Context) error {
+            defer func() {
+                // If for some reason we panic we can recover from it and
+                // invoke our error handler to handle the error surfaced by
+                // the panic.
+                if r := recover(); r != nil {
+                    // Create an error based on the recovery panic message
+                    err := errors.Errorf("%v", r)
+                    // Invoke our error handler with the error created above
+                    c.Error(err)
+                }
+            }()
+            return next(c)
+        }
+    }
+}

--- a/pkg/recovery/middleware_test.go
+++ b/pkg/recovery/middleware_test.go
@@ -1,0 +1,32 @@
+// pkg/recovery/middleware_test.go
+package recovery
+
+import (
+    "errors"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+
+    "github.com/labstack/echo"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestRecovery(t *testing.T) {
+    e := echo.New()
+    e.Use(Middleware())
+
+    e.GET("/panic", func(c echo.Context) error {
+        panic(errors.New("panic test"))
+    })
+
+    req, err := http.NewRequest("GET", "/panic", nil)
+    require.NoError(t, err)
+
+    w := httptest.NewRecorder()
+
+    e.ServeHTTP(w, req)
+
+    assert.Equal(t, http.StatusInternalServerError, w.Code, "incorrect recovered status code")
+    assert.Contains(t, w.Body.String(), "Internal Server Error", "incorrect error message")
+}

--- a/pkg/sentry/sentry.go
+++ b/pkg/sentry/sentry.go
@@ -1,0 +1,35 @@
+// pkg/sentry/sentry.go
+package sentry
+
+import (
+    "github.com/Lianathanoj/goyagi/pkg/config"
+    "github.com/getsentry/raven-go"
+    "github.com/pkg/errors"
+)
+
+// RavenClient provides an interface for the Sentry client.
+type ravenClient interface {
+    Capture(packet *raven.Packet, captureTags map[string]string) (string, chan error)
+}
+
+// Sentry contains a client used to send exceptions to Sentry.io.
+// We are using an interface in our struct instead of the actual
+// client type in order to allow us to mock the clients behavior
+// in our tests.
+type Sentry struct {
+    Client ravenClient
+}
+
+// New returns an instance of Sentry.
+func New(cfg config.Config) (Sentry, error) {
+    defaultTags := map[string]string{
+        "environment": cfg.Environment,
+    }
+
+    client, err := raven.NewWithTags(cfg.SentryDSN, defaultTags)
+    if err != nil {
+        return Sentry{}, errors.Wrap(err, "sentry")
+    }
+
+    return Sentry{client}, nil
+}

--- a/pkg/sentry/sentry_test.go
+++ b/pkg/sentry/sentry_test.go
@@ -1,0 +1,19 @@
+// pkg/sentry/sentry_test.go
+package sentry
+
+import (
+    "testing"
+
+    "github.com/Lianathanoj/goyagi/pkg/config"
+    "github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+    cfg := config.Config{
+        Environment: "test",
+    }
+    sentry, err := New(cfg)
+
+    assert.NoError(t, err)
+    assert.NotNil(t, sentry)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -8,8 +8,10 @@ import (
 
     "github.com/Lianathanoj/goyagi/pkg/application"
     "github.com/Lianathanoj/goyagi/pkg/binder"
+    "github.com/Lianathanoj/goyagi/pkg/errors"
     "github.com/Lianathanoj/goyagi/pkg/health"
     "github.com/Lianathanoj/goyagi/pkg/movies"
+    "github.com/Lianathanoj/goyagi/pkg/recovery"
     "github.com/Lianathanoj/goyagi/pkg/signals"
     "github.com/labstack/echo"
     "github.com/lob/logger-go"
@@ -21,9 +23,6 @@ func New(app application.App) *http.Server {
 
     e := echo.New()
 
-    health.RegisterRoutes(e)
-    movies.RegisterRoutes(e, app)
-
     b := binder.New()
     e.Binder = b
 
@@ -33,6 +32,11 @@ func New(app application.App) *http.Server {
     }
 
     e.Use(logger.Middleware())
+    e.Use(recovery.Middleware())
+
+    health.RegisterRoutes(e)
+    movies.RegisterRoutes(e, app)
+    errors.RegisterErrorHandler(e, app)
 
     // signals.Setup() returns a channel we can wait until it's closed before we
     // shutdown our server


### PR DESCRIPTION
Previous PR: #8 (merge this in only after #8 has gone through. Also remember to rebase after merge.)

**What:** create a custom error handler in our middleware which allows us to customize how we return errors and capture these errors through Sentry for alerting. We also gracefully handle panics (which are similar to uncaught exceptions). 

**Why:** Customizing errors and logging them via Sentry allows us to more easily debug the application in the event things go wrong.