### PR TITLE
feat(metrics): add metrics middleware

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:ebaeb414df9abd72ff910cbd5ea19a4c6c98febbbef756eb07fb6e66b8148ba2"
+  name = "github.com/DataDog/datadog-go"
+  packages = ["statsd"]
+  pruneopts = "UT"
+  revision = "8a13fa761f51039f900738876f2837198fba804f"
+  version = "2.2.0"
+
+[[projects]]
   digest = "1:fed1f537c2f1269fe475a8556c393fe466641682d73ef8fd0491cd3aa1e47bad"
   name = "github.com/certifi/gocertifi"
   packages = ["."]
@@ -292,6 +300,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/DataDog/datadog-go/statsd",
     "github.com/creasty/defaults",
     "github.com/getsentry/raven-go",
     "github.com/go-pg/pg",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,3 +48,7 @@
 [[constraint]]
   name = "github.com/creasty/defaults"
   version = "1.3.0"
+
+[[constraint]]
+  name = "github.com/DataDog/datadog-go"
+  version = "2.2.0"

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -4,6 +4,7 @@ package application
 import (
     "github.com/Lianathanoj/goyagi/pkg/config"
     "github.com/Lianathanoj/goyagi/pkg/database"
+    "github.com/Lianathanoj/goyagi/pkg/metrics"
     "github.com/Lianathanoj/goyagi/pkg/sentry"
     "github.com/go-pg/pg"
     "github.com/pkg/errors"
@@ -12,9 +13,10 @@ import (
 // App contains necessary references that will be persisted throughout the
 // application's lifecycle.
 type App struct {
-    Config config.Config
-    DB     *pg.DB
-    Sentry sentry.Sentry
+    Config  config.Config
+    DB      *pg.DB
+    Sentry  sentry.Sentry
+    Metrics metrics.Metrics
 }
 
 // New creates a new instance of App
@@ -31,5 +33,10 @@ func New() (App, error) {
         return App{}, errors.Wrap(err, "application")
     }
 
-    return App{cfg, db, sentry}, nil
+    m, err := metrics.New(cfg)
+    if err != nil {
+        return App{}, errors.Wrap(err, "application")
+    }
+
+    return App{cfg, db, sentry, m}, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,7 +31,8 @@ func New() Config {
         DatabasePort: 5432,
         SentryDSN: os.Getenv("SENTRY_DSN"),
         StatsdHost: "127.0.0.1",
-        StatsdPort: 8125,}
+        StatsdPort: 8125,
+    }
 
     switch os.Getenv(environmentENV) {
     case "development", "":

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,8 @@ type Config struct {
     Environment      string
     Port             int
     SentryDSN        string
+    StatsdHost       string
+    StatsdPort       int
 }
 
 const environmentENV = "ENVIRONMENT"
@@ -27,7 +29,9 @@ func New() Config {
     cfg := Config{
         Port: 3000,
         DatabasePort: 5432,
-        SentryDSN: os.Getenv("SENTRY_DSN"), }
+        SentryDSN: os.Getenv("SENTRY_DSN"),
+        StatsdHost: "127.0.0.1",
+        StatsdPort: 8125,}
 
     switch os.Getenv(environmentENV) {
     case "development", "":

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,111 @@
+// pkg/metrics/metrics.go
+package metrics
+
+import (
+    "fmt"
+    "time"
+
+    "github.com/DataDog/datadog-go/statsd"
+    "github.com/Lianathanoj/goyagi/pkg/config"
+    "github.com/labstack/echo"
+)
+
+type statsdClient interface {
+    Histogram(name string, value float64, tags []string, rate float64) error
+    Count(name string, value int64, tags []string, rate float64) error
+}
+
+// Metrics functions for metrics clients.
+type Metrics struct {
+    client statsdClient
+}
+
+// Timer facilitates timing and tagging a metric before sending it to Datadog
+// as a Histogram datapoint.
+type Timer struct {
+    name    string
+    metrics *Metrics
+    begin   time.Time
+    tags    []string
+}
+
+const namespace = "goyagi."
+
+// New sets up metric package with a Datadog client.
+func New(cfg config.Config) (Metrics, error) {
+    address := fmt.Sprintf("%s:%d", cfg.StatsdHost, cfg.StatsdPort)
+
+    client, err := statsd.New(address)
+    if err != nil {
+        return Metrics{}, err
+    }
+
+    client.Namespace = namespace
+    client.Tags = []string{
+        fmt.Sprintf("environment:%s", cfg.Environment),
+    }
+
+    return Metrics{client}, nil
+}
+
+// Count increments an event counter in Datadog while disregarding potential
+// errors.
+func (m *Metrics) Count(name string, count int64, tags ...string) {
+    m.client.Count(name, count, tags, 1) // nolint:gosec
+}
+
+// Histogram sends statistical distribution data to Datadog while disregarding
+// potential errors.
+func (m *Metrics) Histogram(name string, value float64, tags ...string) {
+    m.client.Histogram(name, value, tags, 1) // nolint:gosec
+}
+
+// NewTimer returns a Timer object with a set start time
+func (m *Metrics) NewTimer(name string, tags ...string) Timer {
+    return Timer{
+        begin:   time.Now(),
+        metrics: m,
+        name:    name,
+        tags:    tags,
+    }
+}
+
+// End ends a Timer and sends the metric and duration to Datadog as a
+// Histogram datapoint.
+func (t *Timer) End(additionalTags ...string) float64 {
+    duration := time.Since(t.begin)
+    durationInMS := float64(duration / time.Millisecond)
+
+    t.tags = append(t.tags, additionalTags...)
+
+    t.metrics.Histogram(t.name, durationInMS, t.tags...)
+
+    return durationInMS
+}
+
+// Middleware returns an Echo middleware function that begins a timer before a
+// request is handled and ends afterwards.
+func Middleware(m Metrics) func(next echo.HandlerFunc) echo.HandlerFunc {
+    return func(next echo.HandlerFunc) echo.HandlerFunc {
+        return func(c echo.Context) error {
+            methodTag := fmt.Sprintf("method:%s", c.Request().Method)
+
+            // Create a new timer
+            t := m.NewTimer("http.request", methodTag)
+
+            // Continue the execution down the middleware/handler stack
+            if err := next(c); err != nil {
+                c.Error(err)
+            }
+
+            statusCodeTag := fmt.Sprintf("status_code:%d", c.Response().Status)
+            pathTag := fmt.Sprintf("path:%s", c.Path())
+
+            // End the timer once we have succeeded calling the middleware/handler
+            // stack. This function call emits the metric to datadog.
+            t.End(statusCodeTag, pathTag)
+
+            return nil
+        }
+    }
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,146 @@
+// pkg/metrics/metrics_test.go
+package metrics
+
+import (
+    "errors"
+    "net/http"
+    "net/http/httptest"
+    "testing"
+    "time"
+
+    "github.com/Lianathanoj/goyagi/pkg/config"
+    "github.com/labstack/echo"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+const testCount = int64(1)
+const testDuration = float64(50)
+const testRate = float64(1)
+const testMetric = "test_metric"
+const testTag = "foo:bar"
+
+var testTags = []string{testTag}
+
+type mockClient struct {
+    t        *testing.T
+    name     string
+    count    int64
+    duration float64
+    tags     []string
+    rate     float64
+}
+
+func (m *mockClient) Count(name string, count int64, tags []string, rate float64) error {
+    m.name = testMetric
+    m.count = testCount
+    m.tags = testTags
+    m.rate = testRate
+
+    return errors.New("test error")
+}
+
+func (m *mockClient) Histogram(name string, duration float64, tags []string, rate float64) error {
+    m.name = testMetric
+    m.duration = testDuration
+    m.tags = testTags
+    m.rate = testRate
+
+    return errors.New("test error")
+}
+
+func newMockedClient(t *testing.T, cfg config.Config) Metrics {
+    metrics, err := New(cfg)
+    require.NoError(t, err)
+    require.NotNil(t, metrics)
+
+    metrics.client = &mockClient{t, "", 0, 0, []string{}, 0}
+
+    return metrics
+}
+
+func TestCount(t *testing.T) {
+    cfg := config.New()
+
+    t.Run("calls Datadog Count function and ignores error", func(tt *testing.T) {
+        metrics := newMockedClient(t, cfg)
+
+        metrics.Count(testMetric, testCount, testTags...)
+
+        mc, ok := metrics.client.(*mockClient)
+        require.True(t, ok, "unexpected error during type assertion")
+
+        assert.Equal(t, testMetric, mc.name, "inconsistent metric name")
+        assert.Equal(t, testCount, mc.count, "inconsistent metric count")
+        assert.Equal(t, testTags, mc.tags, "inconsistent tags")
+        assert.Equal(t, testRate, mc.rate, "inconsistent rate")
+    })
+}
+
+func TestHistogram(t *testing.T) {
+    cfg := config.New()
+
+    t.Run("calls Datadog Histogram function and ignores error", func(tt *testing.T) {
+        metrics := newMockedClient(t, cfg)
+
+        metrics.Histogram(testMetric, testDuration, testTags...)
+
+        mc, ok := metrics.client.(*mockClient)
+        require.True(t, ok, "unexpected error during type assertion")
+
+        assert.Equal(t, testMetric, mc.name, "inconsistent metric name")
+        assert.Equal(t, testDuration, mc.duration, "inconsistent duration")
+        assert.Equal(t, testTags, mc.tags, "inconsistent tags")
+        assert.Equal(t, testRate, mc.rate, "inconsistent rate")
+    })
+}
+
+func TestTimer(t *testing.T) {
+    cfg := config.New()
+
+    t.Run("calls histogram with correct duration", func(tt *testing.T) {
+        metrics := newMockedClient(t, cfg)
+
+        timer := metrics.NewTimer(testMetric, testTag)
+        require.NotNil(t, timer)
+
+        time.Sleep(time.Duration(testDuration) * time.Millisecond)
+        timer.End()
+
+        mc, ok := metrics.client.(*mockClient)
+        require.True(t, ok, "unexpected error during type assertion")
+
+        assert.Equal(t, testMetric, mc.name, "inconsistent metric name")
+        assert.True(t, testDuration <= mc.duration, "incorrect duration")
+        assert.Equal(t, testTags, mc.tags, "inconsistent tags")
+        assert.Equal(t, testRate, mc.rate, "inconsistent rate")
+    })
+}
+
+func TestMiddleware(t *testing.T) {
+    cfg := config.New()
+
+    t.Run("sends request duration through Datadog client", func(tt *testing.T) {
+        metrics := newMockedClient(t, cfg)
+
+        e := echo.New()
+        e.Use(Middleware(metrics))
+
+        e.GET("/", func(c echo.Context) error {
+            time.Sleep(time.Duration(testDuration) * time.Millisecond)
+            return nil
+        })
+
+        req, err := http.NewRequest("GET", "/", nil)
+        require.NoError(t, err)
+
+        rr := httptest.NewRecorder()
+        e.ServeHTTP(rr, req)
+        assert.Equal(t, http.StatusOK, rr.Code)
+
+        mc, ok := metrics.client.(*mockClient)
+        require.True(t, ok, "unexpected error during type assertion")
+
+        assert.True(t, testDuration <= mc.duration, "incorrect duration")
+    })
+}

--- a/pkg/movies/handlers.go
+++ b/pkg/movies/handlers.go
@@ -27,10 +27,13 @@ func (h *handler) createHandler(c echo.Context) error {
         ReleaseDate: params.ReleaseDate,
     }
 
+    insertTimer := h.app.Metrics.NewTimer("goyagi.movies.create.db")
     _, err := h.app.DB.Model(&movie).Insert()
     if err != nil {
+        insertTimer.End("result:error")
         return err
     }
+    insertTimer.End("result:success")
 
     return c.JSON(http.StatusOK, movie)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -10,6 +10,7 @@ import (
     "github.com/Lianathanoj/goyagi/pkg/binder"
     "github.com/Lianathanoj/goyagi/pkg/errors"
     "github.com/Lianathanoj/goyagi/pkg/health"
+    "github.com/Lianathanoj/goyagi/pkg/metrics"
     "github.com/Lianathanoj/goyagi/pkg/movies"
     "github.com/Lianathanoj/goyagi/pkg/recovery"
     "github.com/Lianathanoj/goyagi/pkg/signals"
@@ -33,6 +34,7 @@ func New(app application.App) *http.Server {
 
     e.Use(logger.Middleware())
     e.Use(recovery.Middleware())
+    e.Use(metrics.Middleware(app.Metrics))
 
     health.RegisterRoutes(e)
     movies.RegisterRoutes(e, app)


### PR DESCRIPTION
Previous PR: #9 (merge this in only after #9 has gone through. Also remember to rebase after merge.)

**What:** add metrics middleware to get more granularity with logging. In particular, we add metrics for creating a movie.

**Why:** Doing so would allow us to determine error counts and request time averages, which is useful for determining if certain actions are going wrong or if bottleneck speeds can be improved upon.